### PR TITLE
fix `vkcodes.cpp` being included multiple times

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -7,7 +7,7 @@
 #include "replayEngine.hpp"
 #include "data.hpp"
 #include "version.hpp"
-#include "vkcodes.cpp"
+#include "vkcodes.hpp"
 
 bool gui::show = false;
 bool gui::inited = false;
@@ -553,7 +553,7 @@ void gui::RenderMain() {
                     menukey = component["key"];
                 }
                 component["key"] = menukey;
-                std::string key = key_name(menukey);
+                std::string key = VkCodes::key_name(menukey);
                 char buf[256];
                 snprintf(buf, 256, "Menu Toggle Key: [%s]", key.c_str());
                 if (ImGui::Button(changekey ? "Menu Toggle Key: ..." : buf)) changekey = true;

--- a/source/vkcodes.cpp
+++ b/source/vkcodes.cpp
@@ -1,3 +1,4 @@
+#include "vkcodes.hpp"
 #include <map>
 #include <algorithm>
 #include <string>
@@ -132,7 +133,7 @@ std::map<uint32_t, std::string> key_names = {
     {VK_OEM_CLEAR, "Clear"},
 };
 
-std::string key_name(uint32_t keycode)
+std::string VkCodes::key_name(uint32_t keycode)
 {
     // find key in map
     for (auto& key : key_names)
@@ -158,7 +159,7 @@ std::string key_name(uint32_t keycode)
     return "Unknown";
 }
 
-uint32_t decode_key(std::string key)
+uint32_t VkCodes::decode_key(std::string key)
 {
     // find key in map
     for (auto& key_ : key_names)

--- a/source/vkcodes.hpp
+++ b/source/vkcodes.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "includes.hpp"
+
+namespace VkCodes {
+    std::string key_name(uint32_t keycode);
+    uint32_t decode_key(std::string key);
+}


### PR DESCRIPTION
created its own header and namespace for
`vkcodes.[ch]pp` and fixed all places where it
was included